### PR TITLE
Add language definition to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,14 @@ sudo docker run --name AwTriX2 -p 7000:7000 -p 7001:7001 --restart always -e TZ=
 # For persistent Data add:
 
 -v pwd:/data
+
+# Set Language
+
+If you want AWTRIX to automatically display some apps like **DayOfTheWeek** in your local language/format (e.g. "Sonntag" instead of "Sunday") you can specify this with an eviroment variable.
+
+```shell
+-e JAVA_TOOL_OPTIONS="-Duser.language=de -Duser.country=DE"
+```
+
+Where `de` is your two-letter language code. (see [ISO 639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes))  
+And "`DE` is your two-letter country code. (see [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2))

--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ If you want AWTRIX to automatically display some apps like **DayOfTheWeek** in y
 ```
 
 Where `de` is your two-letter language code. (see [ISO 639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes))  
-And "`DE` is your two-letter country code. (see [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2))
+And `DE` is your two-letter country code. (see [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2))


### PR DESCRIPTION
I figured out how to change the language settings for AWTRIX.
You just need to set an enviroment variable.